### PR TITLE
Update README for CMSSW_13_1_0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# CMS HLT@Phase2 Tracking Confgurations 
+# CMS HLT@Phase2 Tracking Configurations 
 
 This repository contains the instructions to run 
 
@@ -7,36 +7,12 @@ The old configs and workflows used for the Upgrade DAQ and HLT TDR in 2022 are u
 To setup your cmssw to have the ingredients to run the upgrade hlt tracking configs start with
 
 ```
-scram p -n cmssw CMSSW_13_2_0_pre2
+scram p -n cmssw CMSSW_13_1_0
 cd cmssw/src
 cmsenv
-git cms-merge-topic cms-hlt-upgrade-trk:phase2_hlt_tracking_132
+git cms-merge-topic cms-hlt-upgrade-trk:CMSSW_13_1_0_phase2_hlt_tracking
 scram b -j 4
 ```
-
-Apply the following changes to `HLTrigger/Configuration/python/customizePhase2HLTTracking.py`
-
-This is needed to run the customization to include Patatrack pixel tracks, these changes should be soon included in `cms-hlt-upgrade-trk:phase2_hlt_tracking_132`
-
-_line 179_
-```
--    from RecoPixelVertexing.PixelTriplets.caHitNtupletCUDAPhase2_cfi import caHitNtupletCUDAPhase2 as _pixelTracksCUDAPhase2
-+    from RecoTracker.PixelSeeding.caHitNtupletCUDAPhase2_cfi import caHitNtupletCUDAPhase2 as _pixelTracksCUDAPhase2
-```
-
-_line 188_
-```
--    from RecoPixelVertexing.PixelTrackFitting.pixelTrackSoAFromCUDAPhase2_cfi import pixelTrackSoAFromCUDAPhase2 as _pixelTracksSoAPhase2
-+    from RecoTracker.PixelTrackFitting.pixelTrackSoAFromCUDAPhase2_cfi import pixelTrackSoAFromCUDAPhase2 as _pixelTracksSoAPhase2
-```
-
-_line 201_
-```
--    from RecoPixelVertexing.PixelTrackFitting.pixelTrackProducerFromSoAPhase2_cfi import pixelTrackProducerFromSoAPhase2 as _pixelTrackProducerFromSoAPhase2
-+    from RecoTracker.PixelTrackFitting.pixelTrackProducerFromSoAPhase2_cfi import pixelTrackProducerFromSoAPhase2 as _pixelTrackProducerFromSoAPhase2
-```
-
-At the moment this has been tested with `13_2_0_pre2`
 
 -----
 ### Baseline Tracking Configuration
@@ -46,11 +22,11 @@ To run the *baseline* tracking configuration you can derive it from the simplifi
 ```
 cmsDriver.py Phase2 -s HLT:75e33 \
     --processName=HLTX \
-     --conditions 131X_mcRun4_realistic_v5  \
+     --conditions auto:phase2_realistic_T21  \
      --geometry Extended2026D95 \
      --era Phase2C17I13M9 \
      --eventcontent FEVTDEBUGHLT \
-     --filein=/store/mc/Phase2Spring23DIGIRECOMiniAOD/TT_TuneCP5_14TeV-powheg-pythia8/GEN-SIM-DIGI-RAW-MINIAOD/PU200_Trk1GeV_131X_mcRun4_realistic_v5-v1/30000/01607282-0427-4687-a122-ef0a41220590.root \
+     --filein=/store/mc/Phase2Spring23DIGIRECOMiniAOD/TT_TuneCP5_14TeV-powheg-pythia8/GEN-SIM-DIGI-RAW-MINIAOD/PU200_131X_mcRun4_realistic_v5-v1/50000/023b71b9-1d38-4891-b5e6-d584032d2cc4.root \
      -n 10 \
      --nThreads 10 \
      --customise HLTrigger/Configuration/customizePhase2HLTTracking.customisePhase2HLTForTrackingOnly,HLTrigger/Configuration/customizePhase2HLTTracking.addTrackingValidation
@@ -78,20 +54,22 @@ makeTrackValidationPlots.py plots.root
 ```
 
 -----
-### Patatrack Single Iteration (WIP)
-
-At the moment only a single iteration approach has been implemented in which the all the pixel tracks (including triplets) are produced and used as input for the `initialStep` tracks while the `highPtTriplet` step is dropped. To run it use
+### Patatrack 2-Iteration Configuration
 
 ```
 cmsDriver.py Phase2_Patatrack -s HLT:75e33 \
     --processName=HLTX \
-     --conditions 131X_mcRun4_realistic_v5 \
+     --conditions auto:phase2_realistic_T21 \
      --geometry Extended2026D95 \
      --era Phase2C17I13M9 \
      --eventcontent FEVTDEBUGHLT \
-     --filein=/store/mc/Phase2Spring23DIGIRECOMiniAOD/TT_TuneCP5_14TeV-powheg-pythia8/GEN-SIM-DIGI-RAW-MINIAOD/PU200_Trk1GeV_131X_mcRun4_realistic_v5-v1/30000/01607282-0427-4687-a122-ef0a41220590.root \
+     --filein=/store/mc/Phase2Spring23DIGIRECOMiniAOD/TT_TuneCP5_14TeV-powheg-pythia8/GEN-SIM-DIGI-RAW-MINIAOD/PU200_131X_mcRun4_realistic_v5-v1/50000/023b71b9-1d38-4891-b5e6-d584032d2cc4.root \
      -n 10 \
      --nThreads 10 \
      --customise HLTrigger/Configuration/customizePhase2HLTTracking.customisePhase2HLTForTrackingOnly,HLTrigger/Configuration/customizePhase2HLTTracking.customisePhase2HLTForPatatrack,HLTrigger/Configuration/customizePhase2HLTTracking.addTrackingValidation
 ```
 
+-----
+### Patatrack Single Iteration (WIP)
+
+A single iteration approach will be implemented in which the all the pixel tracks (including triplets) are produced and used as input for the `initialStep` tracks while the `highPtTriplet` step is dropped.


### PR DESCRIPTION
As per title, since `CMSSW_13_1_0` will be the release on which HLT Upgrade studies will be based. People can use this as the basis for possible further developments.